### PR TITLE
Added support for Fallout 4 VR.

### DIFF
--- a/src/lootthread.cpp
+++ b/src/lootthread.cpp
@@ -65,6 +65,7 @@ void LOOTWorker::setGame(const std::string &gameName)
 	("oblivion", GameType::tes4)
 		("fallout3", GameType::fo3)
 		("fallout4", GameType::fo4)
+		("fallout4vr", GameType::fo4)
 		("falloutnv", GameType::fonv)
 		("skyrim", GameType::tes5)
 		("skyrimse", GameType::tes5se);


### PR DESCRIPTION
Added a new value for the *-game* command line option to support Fallout 4 VR. Is required for loot to work with my [Fallout 4 VR plugin](https://github.com/matzman666/modorganizer-game_fallout4vr).